### PR TITLE
"InterpolationType.cc" twice in the source

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,6 @@ set(SOURCES ${CMAKE_SOURCE_DIR}/src/InterpolationType.cc
             ${CMAKE_SOURCE_DIR}/src/xlogx.cc
             ${CMAKE_SOURCE_DIR}/src/functions.cc
             ${CMAKE_SOURCE_DIR}/src/well_functions.cc
-            ${CMAKE_SOURCE_DIR}/src/InterpolationType.cc
             ${CMAKE_SOURCE_DIR}/src/CALPHADFunctions.cc
             ${CMAKE_SOURCE_DIR}/src/CALPHADSpeciesPhaseGibbsEnergy.cc
             ${CMAKE_SOURCE_DIR}/src/CALPHADSpeciesPhaseGibbsEnergyExpansion.cc


### PR DESCRIPTION
Hi,

When debugging this code, I noticed that `${CMAKE_SOURCE_DIR}/src/InterpolationType.cc` was declared twice in the CMakeList. I removed the duplicate.

ND: Also the function defined by `InterpolationType.h` doesn't seem to be used anywhere, but it's maybe future-proofing the code.

Please fell free to close / ignore the PR if it's just noise,

Thanks a lot for open-sourcing Thermo4PFM!

Regards,
Thomas