### PR TITLE
remove 'eps' check for CALPHADConcSolverBinary3Ph2Sl

### DIFF
--- a/src/CALPHADConcSolverBinary3Ph2Sl.cc
+++ b/src/CALPHADConcSolverBinary3Ph2Sl.cc
@@ -63,89 +63,41 @@ void CALPHADConcSolverBinary3Ph2Sl::RHS(
     double xi[3] = { 0., 0., 0. };
     computeXi(ypp_A, xi);
 
-    // This parameter controls a cutoff for when we don't consider the
-    // contribution to the residual for when hphi for a phase is below it.
-    // Negative values correspond to no cutoff.
-    double eps = -1.0e-10;
-
     fvec[0] = -c0_ + hphi0_ * c[0] + hphi1_ * c[1] + hphi2_ * c[2];
 
     // We can choose to enforce two of the three chemical potential equilities.
     // Which two are chosen can impact the convergence rate.
     if (hphi1_ > 0.4)
     {
-        if (hphi0_ < eps)
-        {
-            fvec[1] = 0.0;
-        }
-        else
-        {
-            fvec[1]
-                = q_[0] * (xlogx_deriv(ypp_A[0]) - xlogx_deriv(1. - ypp_A[0]))
+
+        fvec[1] = q_[0] * (xlogx_deriv(ypp_A[0]) - xlogx_deriv(1. - ypp_A[0]))
                   - q_[1] * (xlogx_deriv(ypp_A[1]) - xlogx_deriv(1. - ypp_A[1]))
                   + (xi[0] - xi[1]);
-        }
-        if (hphi2_ < eps)
-        {
-            fvec[2] = 0.0;
-        }
-        else
-        {
-            fvec[2]
-                = q_[1] * (xlogx_deriv(ypp_A[1]) - xlogx_deriv(1. - ypp_A[1]))
+
+        fvec[2] = q_[1] * (xlogx_deriv(ypp_A[1]) - xlogx_deriv(1. - ypp_A[1]))
                   - q_[2] * (xlogx_deriv(ypp_A[2]) - xlogx_deriv(1. - ypp_A[2]))
                   + (xi[1] - xi[2]);
-        }
     }
     else if (hphi2_ > 0.4)
     {
-        if (hphi0_ < eps)
-        {
-            fvec[1] = 0.0;
-        }
-        else
-        {
-            fvec[1]
-                = q_[0] * (xlogx_deriv(ypp_A[0]) - xlogx_deriv(1. - ypp_A[0]))
+
+        fvec[1] = q_[0] * (xlogx_deriv(ypp_A[0]) - xlogx_deriv(1. - ypp_A[0]))
                   - q_[2] * (xlogx_deriv(ypp_A[2]) - xlogx_deriv(1. - ypp_A[2]))
                   + (xi[0] - xi[2]);
-        }
-        if (hphi1_ < eps)
-        {
-            fvec[2] = 0.0;
-        }
-        else
-        {
-            fvec[2]
-                = q_[1] * (xlogx_deriv(ypp_A[1]) - xlogx_deriv(1. - ypp_A[1]))
+
+        fvec[2] = q_[1] * (xlogx_deriv(ypp_A[1]) - xlogx_deriv(1. - ypp_A[1]))
                   - q_[2] * (xlogx_deriv(ypp_A[2]) - xlogx_deriv(1. - ypp_A[2]))
                   + (xi[1] - xi[2]);
-        }
     }
     else
     {
-        if (hphi1_ < eps)
-        {
-            fvec[1] = 0.0;
-        }
-        else
-        {
-            fvec[1]
-                = q_[0] * (xlogx_deriv(ypp_A[0]) - xlogx_deriv(1. - ypp_A[0]))
+        fvec[1] = q_[0] * (xlogx_deriv(ypp_A[0]) - xlogx_deriv(1. - ypp_A[0]))
                   - q_[1] * (xlogx_deriv(ypp_A[1]) - xlogx_deriv(1. - ypp_A[1]))
                   + (xi[0] - xi[1]);
-        }
-        if (hphi2_ < eps)
-        {
-            fvec[2] = 0.0;
-        }
-        else
-        {
-            fvec[2]
-                = q_[0] * (xlogx_deriv(ypp_A[0]) - xlogx_deriv(1. - ypp_A[0]))
+
+        fvec[2] = q_[0] * (xlogx_deriv(ypp_A[0]) - xlogx_deriv(1. - ypp_A[0]))
                   - q_[2] * (xlogx_deriv(ypp_A[2]) - xlogx_deriv(1. - ypp_A[2]))
                   + (xi[0] - xi[2]);
-        }
     }
 
     // Debugging output
@@ -187,15 +139,15 @@ void CALPHADConcSolverBinary3Ph2Sl::computeDxiDc(
     // loop over phases
     dxidc[0] = RTinv_
                * CALPHADcomputeFMix_deriv2Binary(
-                     Lmix_L_[0], Lmix_L_[1], Lmix_L_[2], Lmix_L_[3], c[0]);
+                   Lmix_L_[0], Lmix_L_[1], Lmix_L_[2], Lmix_L_[3], c[0]);
 
     dxidc[1] = RTinv_
                * CALPHADcomputeFMix_deriv2Binary(
-                     Lmix_S0_[0], Lmix_S0_[1], Lmix_S0_[2], Lmix_S0_[3], c[1]);
+                   Lmix_S0_[0], Lmix_S0_[1], Lmix_S0_[2], Lmix_S0_[3], c[1]);
 
     dxidc[2] = RTinv_
                * CALPHADcomputeFMix_deriv2Binary(
-                     Lmix_S1_[0], Lmix_S1_[1], Lmix_S1_[2], Lmix_S1_[3], c[2]);
+                   Lmix_S1_[0], Lmix_S1_[1], Lmix_S1_[2], Lmix_S1_[3], c[2]);
 }
 
 //=======================================================================
@@ -222,55 +174,55 @@ void CALPHADConcSolverBinary3Ph2Sl::Jacobian(
     {
         fjac[1][0] = (p_[0] + q_[0])
                      * (dxidc[0] + q_[0] * xlogx_deriv2(ypp_A[0])
-                           + q_[0] * xlogx_deriv2(1. - ypp_A[0]));
+                         + q_[0] * xlogx_deriv2(1. - ypp_A[0]));
         fjac[1][1] = (p_[1] + q_[1])
                      * (-dxidc[1] - q_[1] * xlogx_deriv2(ypp_A[1])
-                           - q_[1] * xlogx_deriv2(1. - ypp_A[1]));
+                         - q_[1] * xlogx_deriv2(1. - ypp_A[1]));
         fjac[1][2] = 0.;
 
         fjac[2][0] = 0.;
         fjac[2][1] = (p_[1] + q_[1])
                      * (dxidc[1] + q_[1] * xlogx_deriv2(ypp_A[1])
-                           + q_[1] * xlogx_deriv2(1. - ypp_A[1]));
+                         + q_[1] * xlogx_deriv2(1. - ypp_A[1]));
         fjac[2][2] = (p_[2] + q_[2])
                      * (-dxidc[2] - q_[2] * xlogx_deriv2(ypp_A[2])
-                           - q_[2] * xlogx_deriv2(1. - ypp_A[2]));
+                         - q_[2] * xlogx_deriv2(1. - ypp_A[2]));
     }
     if (hphi2_ > 0.4)
     {
         fjac[1][0] = (p_[0] + q_[0])
                      * (dxidc[0] + q_[0] * xlogx_deriv2(ypp_A[0])
-                           + q_[0] * xlogx_deriv2(1. - ypp_A[0]));
+                         + q_[0] * xlogx_deriv2(1. - ypp_A[0]));
         fjac[1][1] = 0.;
         fjac[1][2] = (p_[2] + q_[2])
                      * (-dxidc[2] - q_[2] * xlogx_deriv2(ypp_A[2])
-                           - q_[2] * xlogx_deriv2(1. - ypp_A[2]));
+                         - q_[2] * xlogx_deriv2(1. - ypp_A[2]));
 
         fjac[2][0] = 0.;
         fjac[2][1] = (p_[1] + q_[1])
                      * (dxidc[1] + q_[1] * xlogx_deriv2(ypp_A[1])
-                           + q_[1] * xlogx_deriv2(1. - ypp_A[1]));
+                         + q_[1] * xlogx_deriv2(1. - ypp_A[1]));
         fjac[2][2] = (p_[2] + q_[2])
                      * (-dxidc[2] - q_[2] * xlogx_deriv2(ypp_A[2])
-                           - q_[2] * xlogx_deriv2(1. - ypp_A[2]));
+                         - q_[2] * xlogx_deriv2(1. - ypp_A[2]));
     }
     else
     {
         fjac[1][0] = (p_[0] + q_[0])
                      * (dxidc[0] + q_[0] * xlogx_deriv2(ypp_A[0])
-                           + q_[0] * xlogx_deriv2(1. - ypp_A[0]));
+                         + q_[0] * xlogx_deriv2(1. - ypp_A[0]));
         fjac[1][1] = (p_[1] + q_[1])
                      * (-dxidc[1] - q_[1] * xlogx_deriv2(ypp_A[1])
-                           - q_[1] * xlogx_deriv2(1. - ypp_A[1]));
+                         - q_[1] * xlogx_deriv2(1. - ypp_A[1]));
         fjac[1][2] = 0.;
 
         fjac[2][0] = (p_[0] + q_[0])
                      * (dxidc[0] + q_[0] * xlogx_deriv2(ypp_A[0])
-                           + q_[0] * xlogx_deriv2(1. - ypp_A[0]));
+                         + q_[0] * xlogx_deriv2(1. - ypp_A[0]));
         fjac[2][1] = 0.;
         fjac[2][2] = (p_[2] + q_[2])
                      * (-dxidc[2] - q_[2] * xlogx_deriv2(ypp_A[2])
-                           - q_[2] * xlogx_deriv2(1. - ypp_A[2]));
+                         - q_[2] * xlogx_deriv2(1. - ypp_A[2]));
     }
 }
 


### PR DESCRIPTION
After adding the restart capability, this is no longer required for convergence.