### PR TITLE
Comment out `std::cerr` in device code

### DIFF
--- a/src/CALPHADFreeEnergyFunctionsBinary2Ph1Sl.cc
+++ b/src/CALPHADFreeEnergyFunctionsBinary2Ph1Sl.cc
@@ -262,9 +262,11 @@ void CALPHADFreeEnergyFunctionsBinary2Ph1Sl::computeTdependentParameters(
 bool CALPHADFreeEnergyFunctionsBinary2Ph1Sl::computeCeqT(
     const double temperature, double* ceq, const int maxits, const bool verbose)
 {
-//    std::cerr << "CALPHADFreeEnergyFunctionsBinary2Ph1Sl::computeCeqT() not "
-//                 "implemented"
-//              << std::endl;
+#ifndef HAVE_OPENMP_OFFLOAD
+    std::cerr << "CALPHADFreeEnergyFunctionsBinary2Ph1Sl::computeCeqT() not "
+                 "implemented"
+              << std::endl;
+#endif
     return false;
 }
 

--- a/src/CALPHADFreeEnergyFunctionsBinary2Ph1Sl.cc
+++ b/src/CALPHADFreeEnergyFunctionsBinary2Ph1Sl.cc
@@ -262,9 +262,9 @@ void CALPHADFreeEnergyFunctionsBinary2Ph1Sl::computeTdependentParameters(
 bool CALPHADFreeEnergyFunctionsBinary2Ph1Sl::computeCeqT(
     const double temperature, double* ceq, const int maxits, const bool verbose)
 {
-    std::cerr << "CALPHADFreeEnergyFunctionsBinary2Ph1Sl::computeCeqT() not "
-                 "implemented"
-              << std::endl;
+//    std::cerr << "CALPHADFreeEnergyFunctionsBinary2Ph1Sl::computeCeqT() not "
+//                 "implemented"
+//              << std::endl;
     return false;
 }
 


### PR DESCRIPTION
Hi,

`std::cerr` is not avalaible in a Offload region. Intel compiler complain with
```
Thermo4PFM/src/CALPHADFreeEnergyFunctionsBinary2Ph1Sl.cc:265:5: error: variable 'cerr' used but not marked as declare target
    std::cerr << "CALPHADFreeEnergyFunctionsBinary2Ph1Sl::computeCeqT() not "
    ^
/soft/packaging/spack-builds/linux-opensuse_leap15-x86_64/gcc-10.2.0/gcc-10.2.0-yudlyezca7twgd5o3wkkraur7wdbngdn/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/iostream:62:3: note: 'cerr' declared here
  extern ostream cerr;          /// Linked to standard error (unbuffered)
  ^
1 error generated.
```

This just comment out std::cerr

