### PR TITLE
Do not enforce composition<=1

### DIFF
--- a/src/CALPHADFreeEnergyFunctionsBinary.cc
+++ b/src/CALPHADFreeEnergyFunctionsBinary.cc
@@ -168,9 +168,6 @@ void CALPHADFreeEnergyFunctionsBinary::computeSecondDerivativeFreeEnergy(
     const double temp, const double* const conc, const PhaseIndex pi,
     double* d2fdc2)
 {
-    // assert(conc[0] >= 0.);
-    // assert(conc[0] <= 1.);
-
     const CalphadDataType l0 = lmixPhase(0, pi, temp);
     const CalphadDataType l1 = lmixPhase(1, pi, temp);
     const CalphadDataType l2 = lmixPhase(2, pi, temp);
@@ -300,11 +297,6 @@ int CALPHADFreeEnergyFunctionsBinary::computePhaseConcentrations(
     const double temperature, const double* const conc, const double* const phi,
     double* x)
 {
-    // assert(x[0] >= 0.);
-    // assert(x[1] >= 0.);
-    // assert(x[0] <= 1.);
-    // assert(x[1] <= 1.);
-
     const double RTinv = 1.0 / (GASCONSTANT_R_JPKPMOL * temperature);
 
     CalphadDataType fA[2];
@@ -316,13 +308,10 @@ int CALPHADFreeEnergyFunctionsBinary::computePhaseConcentrations(
 
     const double hphi = interp_func(conc_interp_func_type_, phi[0]);
 
-    // conc could be outside of [0.,1.] in a trial step
-    double c0 = conc[0] >= 0. ? conc[0] : 0.;
-    c0        = c0 <= 1. ? c0 : 1.;
-    // solve system of equations to find (cl,cs) given c0 and hphi
+    // solve system of equations to find (cl,cs) given conc[0] and hphi
     // x: initial guess and solution
     CALPHADConcSolverBinary solver;
-    solver.setup(c0, hphi, RTinv, Lmix_L, Lmix_A, fA, fB);
+    solver.setup(conc[0], hphi, RTinv, Lmix_L, Lmix_A, fA, fB);
     int ret = solver.ComputeConcentration(
         x, newton_tol_, newton_maxits_, newton_alpha_);
 #if 0

--- a/src/CALPHADFreeEnergyFunctionsBinary2Ph1Sl.cc
+++ b/src/CALPHADFreeEnergyFunctionsBinary2Ph1Sl.cc
@@ -201,9 +201,6 @@ void CALPHADFreeEnergyFunctionsBinary2Ph1Sl::computeSecondDerivativeFreeEnergy(
     const double temp, const double* const conc, const PhaseIndex pi,
     double* d2fdc2)
 {
-    // assert(conc[0] >= 0.);
-    // assert(conc[0] <= 1.);
-
     const CalphadDataType l0 = lmixPhase(0, pi, temp);
     const CalphadDataType l1 = lmixPhase(1, pi, temp);
     const CalphadDataType l2 = lmixPhase(2, pi, temp);
@@ -366,11 +363,6 @@ int CALPHADFreeEnergyFunctionsBinary2Ph1Sl::computePhaseConcentrations(
     const double temperature, const double* const conc, const double* const phi,
     double* x)
 {
-    // assert(x[0] >= 0.);
-    // assert(x[1] >= 0.);
-    // assert(x[0] <= 1.);
-    // assert(x[1] <= 1.);
-
     const double RTinv = 1.0 / (GASCONSTANT_R_JPKPMOL * temperature);
 
     CalphadDataType fA[2];
@@ -390,13 +382,10 @@ int CALPHADFreeEnergyFunctionsBinary2Ph1Sl::computePhaseConcentrations(
     q[0] = sublattice_stoichiometry_phaseL_[1];
     q[1] = sublattice_stoichiometry_phaseA_[1];
 
-    // conc could be outside of [0.,1.] in a trial step
-    double c0 = conc[0] >= 0. ? conc[0] : 0.;
-    c0        = c0 <= 1. ? c0 : 1.;
-    // solve system of equations to find (cl,cs) given c0 and hphi
+    // solve system of equations to find (cl,cs) given conc[0] and hphi
     // x: initial guess and solution
     CALPHADConcSolverBinary2Ph1Sl solver;
-    solver.setup(c0, hphi, RTinv, Lmix_L, Lmix_A, fA, fB, p, q);
+    solver.setup(conc[0], hphi, RTinv, Lmix_L, Lmix_A, fA, fB, p, q);
     int ret = solver.ComputeConcentration(
         x, newton_tol_, newton_maxits_, newton_alpha_);
 #if 0

--- a/src/CALPHADFreeEnergyFunctionsBinary3Ph2Sl.cc
+++ b/src/CALPHADFreeEnergyFunctionsBinary3Ph2Sl.cc
@@ -217,9 +217,6 @@ void CALPHADFreeEnergyFunctionsBinary3Ph2Sl::computeSecondDerivativeFreeEnergy(
     const double temp, const double* const conc, const PhaseIndex pi,
     double* d2fdc2)
 {
-    // assert(conc[0] >= 0.);
-    // assert(conc[0] <= 1.);
-
     const CalphadDataType l0 = lmixPhase(0, pi, temp);
     const CalphadDataType l1 = lmixPhase(1, pi, temp);
     const CalphadDataType l2 = lmixPhase(2, pi, temp);
@@ -408,11 +405,6 @@ int CALPHADFreeEnergyFunctionsBinary3Ph2Sl::computePhaseConcentrations(
     const double temperature, const double* const conc, const double* const phi,
     double* x)
 {
-    // assert(x[0] >= 0.);
-    // assert(x[1] >= 0.);
-    // assert(x[0] <= 1.);
-    // assert(x[1] <= 1.);
-
     const double RTinv = 1.0 / (GASCONSTANT_R_JPKPMOL * temperature);
 
     CalphadDataType fA[3];
@@ -437,14 +429,11 @@ int CALPHADFreeEnergyFunctionsBinary3Ph2Sl::computePhaseConcentrations(
     q[1] = sublattice_stoichiometry_phaseA_[1];
     q[2] = sublattice_stoichiometry_phaseB_[1];
 
-    // conc could be outside of [0.,1.] in a trial step
-    double c0 = conc[0] >= 0. ? conc[0] : 0.;
-    c0        = c0 <= 1. ? c0 : 1.;
-    // solve system of equations to find (cl,cs) given c0 and hphi
+    // solve system of equations to find (cl,cs) given conc[0] and hphi
     // x: initial guess and solution
     CALPHADConcSolverBinary3Ph2Sl solver;
-    solver.setup(
-        c0, hphi0, hphi1, hphi2, RTinv, Lmix_L, Lmix_A, Lmix_B, fA, fB, p, q);
+    solver.setup(conc[0], hphi0, hphi1, hphi2, RTinv, Lmix_L, Lmix_A, Lmix_B,
+        fA, fB, p, q);
 
     // Loop that changes the initial conditions if the solver doesn't converge
     int ret         = -1;

--- a/src/CALPHADFreeEnergyFunctionsBinaryThreePhase.cc
+++ b/src/CALPHADFreeEnergyFunctionsBinaryThreePhase.cc
@@ -188,9 +188,6 @@ void CALPHADFreeEnergyFunctionsBinaryThreePhase::
     computeSecondDerivativeFreeEnergy(const double temp,
         const double* const conc, const PhaseIndex pi, double* d2fdc2)
 {
-    // assert(conc[0] >= 0.);
-    // assert(conc[0] <= 1.);
-
     const CalphadDataType l0 = lmixPhase(0, pi, temp);
     const CalphadDataType l1 = lmixPhase(1, pi, temp);
     const CalphadDataType l2 = lmixPhase(2, pi, temp);
@@ -298,11 +295,6 @@ int CALPHADFreeEnergyFunctionsBinaryThreePhase::computePhaseConcentrations(
     const double temperature, const double* const conc, const double* const phi,
     double* x)
 {
-    // assert(x[0] >= 0.);
-    // assert(x[1] >= 0.);
-    // assert(x[0] <= 1.);
-    // assert(x[1] <= 1.);
-
     const double RT = GASCONSTANT_R_JPKPMOL * temperature;
 
     CalphadDataType fA[3];
@@ -317,13 +309,11 @@ int CALPHADFreeEnergyFunctionsBinaryThreePhase::computePhaseConcentrations(
     const double hphi1 = interp_func(conc_interp_func_type_, phi[1]);
     const double hphi2 = interp_func(conc_interp_func_type_, phi[2]);
 
-    // conc could be outside of [0.,1.] in a trial step
-    double c0 = conc[0] >= 0. ? conc[0] : 0.;
-    c0        = c0 <= 1. ? c0 : 1.;
-    // solve system of equations to find (cl,cs) given c0 and hphi
+    // solve system of equations to find (cl,cs) given conc[0] and hphi
     // x: initial guess and solution
     CALPHADConcSolverBinaryThreePhase solver;
-    solver.setup(c0, hphi0, hphi1, hphi2, RT, Lmix_L, Lmix_A, Lmix_B, fA, fB);
+    solver.setup(
+        conc[0], hphi0, hphi1, hphi2, RT, Lmix_L, Lmix_A, Lmix_B, fA, fB);
     int ret = solver.ComputeConcentration(
         x, newton_tol_, newton_maxits_, newton_alpha_);
 #if 0

--- a/src/CALPHADFreeEnergyFunctionsTernary.cc
+++ b/src/CALPHADFreeEnergyFunctionsTernary.cc
@@ -319,11 +319,6 @@ void CALPHADFreeEnergyFunctionsTernary::computeSecondDerivativeFreeEnergy(
     const double temp, const double* const conc, const PhaseIndex pi,
     double* d2fdc2)
 {
-    // assert(conc[0] >= 0.);
-    // assert(conc[0] <= 1.);
-    // assert(conc[1] >= 0.);
-    // assert(conc[1] <= 1.);
-
     CalphadDataType lAB[4]  = { lmix0ABPhase(pi, temp), lmix1ABPhase(pi, temp),
         lmix2ABPhase(pi, temp), lmix3ABPhase(pi, temp) };
     CalphadDataType lAC[4]  = { lmix0ACPhase(pi, temp), lmix1ACPhase(pi, temp),
@@ -572,13 +567,6 @@ int CALPHADFreeEnergyFunctionsTernary::computePhaseConcentrations(
 {
     // assert(conc[0] == conc[0]);
     // assert(conc[1] == conc[1]);
-    // assert(x[0] >= 0.);
-    // assert(x[1] >= 0.);
-    // assert(x[0] <= 1.);
-    // assert(x[1] <= 1.);
-
-    const double conc0 = conc[0];
-    const double conc1 = conc[1];
 
     const double RTinv = 1.0 / (GASCONSTANT_R_JPKPMOL * temperature);
 
@@ -604,15 +592,9 @@ int CALPHADFreeEnergyFunctionsTernary::computePhaseConcentrations(
 
     const double hphi = interp_func(conc_interp_func_type_, phi[0]);
 
-    // conc could be outside of [0.,1.] in a trial step
-    double c0 = conc0 >= 0. ? conc0 : 0.;
-    c0        = c0 <= 1. ? c0 : 1.;
-    double c1 = conc1 >= 0. ? conc1 : 0.;
-    c1        = c1 <= 1. ? c1 : 1.;
-
     CALPHADConcSolverTernary solver;
-    solver.setup(c0, c1, hphi, RTinv, L_AB_L, L_AC_L, L_BC_L, L_AB_S, L_AC_S,
-        L_BC_S, L_ABC_L, L_ABC_S, fA, fB, fC);
+    solver.setup(conc[0], conc[1], hphi, RTinv, L_AB_L, L_AC_L, L_BC_L, L_AB_S,
+        L_AC_S, L_BC_S, L_ABC_L, L_ABC_S, fA, fB, fC);
     int ret = solver.ComputeConcentration(x, newton_tol_, newton_maxits_);
 #ifndef HAVE_OPENMP_OFFLOAD
     if (ret == -1)
@@ -621,7 +603,7 @@ int CALPHADFreeEnergyFunctionsTernary::computePhaseConcentrations(
                      "CALPHADFreeEnergyFunctionsTernary::"
                      "computePhaseConcentrations() "
                      "failed for conc0="
-                  << conc0 << ", conc1=" << conc1 << ", hphi=" << hphi
+                  << conc[0] << ", conc1=" << conc[1] << ", hphi=" << hphi
                   << std::endl;
     }
 #endif


### PR DESCRIPTION
There were a few instances where this condition was applied to input composition. This can lead to inconsistencies between KKS solution and composition in calling code. Calling code could enforce that constraint outside solver if deemed necessary or useful.